### PR TITLE
Add 'rest' setting & Optimize default val

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -80,6 +80,7 @@ if __name__ == "__main__":
             timeout=settingConfig["request"]["timeout"],
             proxy=settingConfig["request"]["proxy"],
             isDebug=settingConfig["dev"]["debug"],
+            rest=settingConfig["request"]["rest"],
         )
 
         api = Bilibili(

--- a/interface/CLI/setting.py
+++ b/interface/CLI/setting.py
@@ -31,6 +31,8 @@ class SettingCli:
             "request": {
                 # 请求间隔
                 "sleep": 0.8,
+                # 412风控间隔
+                "rest": 60.0,
                 # 超时
                 "timeout": 3.0,
                 # 代理
@@ -94,6 +96,18 @@ class SettingCli:
             return float(interval)
 
         @logger.catch
+        def RestStep() -> float:
+            """
+            412风控间隔
+            """
+            rest = self.data.Inquire(
+                type="Text",
+                message="请输入触发412风控时暂停的时间(单位:秒), 建议高于默认值!",
+                default="60",
+            )
+            return float(rest)
+
+        @logger.catch
         def NoticeStep() -> tuple[bool, bool, bool, str]:
             """
             提醒
@@ -142,6 +156,7 @@ class SettingCli:
 
         print("下面开始配置设置!")
         self.config["request"]["sleep"] = SleepStep()
+        self.config["request"]["rest"] = RestStep()
         (
             self.config["notice"]["system"],
             self.config["notice"]["sound"],

--- a/util/Request/__init__.py
+++ b/util/Request/__init__.py
@@ -20,6 +20,7 @@ class Request:
         proxy: str | None = None,
         redirect: bool = True,
         isDebug: bool = False,
+        rest: float = 60.0,
     ):
         """
         初始化
@@ -29,6 +30,7 @@ class Request:
         proxy: 代理
         redirect: 重定向
         isDebug: 调试模式
+        rest: 412风控间隔
         """
 
         self.cookie = cookie
@@ -36,6 +38,7 @@ class Request:
         self.proxy = proxy
         self.redirect = redirect
         self.isDebug = isDebug
+        self.rest = rest
 
         self.header = {
             "Accept": "*/*",
@@ -143,8 +146,8 @@ class Request:
         # 错误
         if response.status_code != 200:
             if response.status_code == 412:
-                logger.error("【Request响应】IP被B站封禁(412风控)!!!!! 下面暂停工作30秒, 请更换IP后再次使用(重启路由器/使用手机流量热点/代理...)")
-                sleep(30)
+                logger.error(f"【Request响应】IP被B站封禁(412风控)!!!!! 下面暂停工作{self.rest}秒, 请更换IP后再次使用(重启路由器/使用手机流量热点/代理...)")
+                sleep(self.rest)
 
             # 等于100001
             elif response.status_code == 429 or "show.bilibili.com" not in str(request.url):


### PR DESCRIPTION
增加 'rest' 配置，用于指定触发412风控后的暂停时长。
由于当前默认30s暂停几乎不会缓解412，因此更改默认值到60s。